### PR TITLE
Update API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming
 
+* Rename `GitHubState` to `GitHubSettings`
+
 ## 1.0.3
 
 * Fix goldens after GitHub changed documentation URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 * Rename `GitHubState` to `GitHubSettings`
+* Remove `queryGitHubPage'` -- implement `queryGitHubPage` in `MonadGitHubREST` instead.
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Upcoming
 
+## 1.1.0
+
 * Rename `GitHubState` to `GitHubSettings`
 * Remove `queryGitHubPage'` -- implement `queryGitHubPage` in `MonadGitHubREST` instead.
 * Expose `queryGitHubPageIO` if users want to manually implement `MonadGitHubREST`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Rename `GitHubState` to `GitHubSettings`
 * Remove `queryGitHubPage'` -- implement `queryGitHubPage` in `MonadGitHubREST` instead.
+* Expose `queryGitHubPageIO` if users want to manually implement `MonadGitHubREST`
 
 ## 1.0.3
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import Network.HTTP.Types (StdMethod(..))
 default (Text)
 
 main = do
-  let state = GitHubState
+  let state = GitHubSettings
         { token = Nothing
           -- ^ An authentication token to use, if any.
         , userAgent = "alice/my-project"

--- a/github-rest.cabal
+++ b/github-rest.cabal
@@ -1,13 +1,13 @@
 cabal-version: >= 1.10
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9626757e084e5f6d0d88ae12dee832d693aa6ae2dea9283634eb783be14cfe9f
+-- hash: 800fa4f169210c967d917bacbc61e12d696ad192e8744af6798c68552fd8c05c
 
 name:           github-rest
-version:        1.0.3
+version:        1.1.0
 synopsis:       Query the GitHub REST API programmatically
 description:    Query the GitHub REST API programmatically, which can provide a more
                 flexible and clear interface than if all of the endpoints and their types

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: github-rest
-version: 1.0.3
+version: 1.1.0
 verbatim:
   cabal-version: '>= 1.10'
 license: BSD3

--- a/src/GitHub/REST.hs
+++ b/src/GitHub/REST.hs
@@ -12,7 +12,7 @@ module GitHub.REST
   -- * Monad transformer and type-class for querying the GitHub REST API
     MonadGitHubREST(..)
   , GitHubT
-  , GitHubState(..)
+  , GitHubSettings(..)
   , runGitHubT
   -- * GitHub authentication
   , Token(..)

--- a/test/Query.hs
+++ b/test/Query.hs
@@ -30,7 +30,7 @@ tests =
 goldens :: TestName -> String -> GitHubT IO ByteString -> TestTree
 goldens name fp action = goldenVsString name ("test/goldens/" ++ fp) $ runGitHubT state action
   where
-    state = GitHubState
+    state = GitHubSettings
       { token = Nothing
       , userAgent = "github-rest"
       , apiVersion = "v3"


### PR DESCRIPTION
The main change in this PR is to expose `queryGitHubPageIO` so that users can implement `MonadGitHubREST` as they want to, without being tied to using `GitHubT` as a monad transformer (e.g. if they want to store the manager in their own reader environment).

With this change, `GitHubSettings` makes more sense, since `GitHubState` doesn't make sense as a public API; from the user's perspective, there's no state involved. Also removed `queryGitHubPage'`, since I don't think anyone would actually want to distinguish between JSON decoding errors and some other GitHub error. Can always add it back in, I suppose, but I think it makes more sense to have `MonadGitHubREST`'s primitive be `queryGitHubPage`