### PR TITLE
Support jwt-0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+## 1.1.2
+
+* Add support for `jwt-0.11.0`
+
 ## 1.1.1
 
 * Add support for `aeson-2.0.0.0`

--- a/github-rest.cabal
+++ b/github-rest.cabal
@@ -5,7 +5,7 @@ cabal-version: >= 1.10
 -- see: https://github.com/sol/hpack
 
 name:           github-rest
-version:        1.1.1
+version:        1.1.2
 synopsis:       Query the GitHub REST API programmatically
 description:    Query the GitHub REST API programmatically, which can provide a more
                 flexible and clear interface than if all of the endpoints and their types

--- a/github-rest.cabal
+++ b/github-rest.cabal
@@ -50,7 +50,7 @@ library
     , http-client >=0.5.13.1 && <0.8
     , http-client-tls >=0.3.5.3 && <0.4
     , http-types >=0.12.1 && <0.13
-    , jwt >=0.9.0 && <0.11
+    , jwt >=0.9.0 && <0.12
     , mtl >=2.2.2 && <2.3
     , scientific >=0.3.6.2 && <0.4
     , text >=1.2.2.2 && <1.3
@@ -86,7 +86,7 @@ test-suite github-rest-test
     , http-client >=0.5.13.1 && <0.8
     , http-client-tls >=0.3.5.3 && <0.4
     , http-types >=0.12.1 && <0.13
-    , jwt >=0.9.0 && <0.11
+    , jwt >=0.9.0 && <0.12
     , mtl >=2.2.2 && <2.3
     , scientific >=0.3.6.2 && <0.4
     , tasty

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: github-rest
-version: 1.1.1
+version: 1.1.2
 verbatim:
   cabal-version: '>= 1.10'
 license: BSD3

--- a/package.yaml
+++ b/package.yaml
@@ -40,7 +40,7 @@ dependencies:
 - http-client >= 0.5.13.1 && < 0.8
 - http-client-tls >= 0.3.5.3 && < 0.4
 - http-types >= 0.12.1 && < 0.13
-- jwt >= 0.9.0 && < 0.11
+- jwt >= 0.9.0 && < 0.12
 - mtl >= 2.2.2 && < 2.3
 - scientific >= 0.3.6.2 && < 0.4
 - text >= 1.2.2.2 && < 1.3

--- a/stack-ghc-9.0.yaml
+++ b/stack-ghc-9.0.yaml
@@ -2,7 +2,8 @@ resolver: nightly-2021-11-28
 
 extra-deps:
   - aeson-2.0.2.0
-  - jwt-0.10.1
+  - cryptostore-0.2.1.0
+  - jwt-0.11.0
 
 flags:
   cryptonite:

--- a/stack-ghc-9.2.yaml
+++ b/stack-ghc-9.2.yaml
@@ -6,7 +6,8 @@ extra-deps:
   - attoparsec-0.14.2
   - base-compat-0.12.1
   - base-compat-batteries-0.12.1
-  - jwt-0.10.1
+  - cryptostore-0.2.1.0
+  - jwt-0.11.0
   # https://github.com/haskell-foundation/foundation/pull/555
   - github: haskell-foundation/foundation
     commit: 0bb195e1fea06d144dafc5af9a0ff79af0a5f4a0


### PR DESCRIPTION
After merging, make new release.

Making this a minor version bump because the change is backwards-compatible.